### PR TITLE
Fixed wrong URL and credential in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ you can start an OJS stack (web app + database containers) with a single command
 
     Docker-compose will pull images from docker Hub and do all the hard work to rise a functional OJS stack.
 
-4. Access **http://127.0.0.1:8080** and continue through web installation process.
+4. Access **http://127.0.0.1:8081** and continue through web installation process.
 
     Note that the database connection needs the following options:
 
     - **Database driver**: `mysqli` (or "mysql" if your php is lower than 7.3)
     - **Host**: `db` (which is the name of the container in the internal Docker network)
     - **Username**: `ojs`
-    - **Password**: `ojsPwd`
+    - **Password**: `ojs`
     - **Database name**: `ojs`
     - _Uncheck_ "Create new database"
     - _Uncheck_ "Beacon"


### PR DESCRIPTION
In the current version, the README gives the wrong URL and the password for the database is wrong. This PR fixes the documentation.