### PR TITLE
remove duplicated restart: always in docker-compose yml files

### DIFF
--- a/templates/dockerComposes/docker-compose-apache-adminer-traefik.template
+++ b/templates/dockerComposes/docker-compose-apache-adminer-traefik.template
@@ -34,7 +34,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME}"
     hostname: "${COMPOSE_PROJECT_NAME}"
-    restart: always
     ports:
       - "${HTTP_PORT}:80"
       - "${HTTPS_PORT}:443"

--- a/templates/dockerComposes/docker-compose-apache.template
+++ b/templates/dockerComposes/docker-compose-apache.template
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/templates/dockerComposes/docker-compose-nginx.template
+++ b/templates/dockerComposes/docker-compose-nginx.template
@@ -31,7 +31,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME}"
     hostname: "${COMPOSE_PROJECT_NAME}"
-    restart: always
     ports:
       - "${HTTP_PORT}:80"
       - "${HTTPS_PORT}:443"

--- a/versions/2.3.2-1/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2.3.2-1/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2.3.2-1/alpine/apache/php5/docker-compose.yml
+++ b/versions/2.3.2-1/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_0_0-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_0_0-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_0_0-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_0_0-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_0_1-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_0_1-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_0_1-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_0_1-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_0_2-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_0_2-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_0_2-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_0_2-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_0_2-1/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_0_2-1/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_0_2-1/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_0_2-1/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_1_0-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_1_0-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_1_0-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_1_0-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_1_0-1/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_1_0-1/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_1_0-1/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_1_0-1/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_1_1-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_1_1-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_1_1-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_1_1-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_1_1rc4/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_1_1rc4/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_1_1rc4/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_1_1rc4/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_1b/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_1b/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_1b/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_1b/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_2_0-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_2_0-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_2_0-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_2_0-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_2_0-b1/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_2_0-b1/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_2_0-b1/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_2_0-b1/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_2_0-b2/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_2_0-b2/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_2_0-b2/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_2_0-b2/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_2_1-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_2_1-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_2_1-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_2_1-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_2_1-b1/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_2_1-b1/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_2_1-b1/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_2_1-b1/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_2_2-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_2_2-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_2_2-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_2_2-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_2_3-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_2_3-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_2_3-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_2_3-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_2_3-0rc1/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_2_3-0rc1/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_2_3-0rc1/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_2_3-0rc1/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_2_4-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_2_4-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_2_4-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_2_4-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_0-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_3_0-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_0-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_3_0-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_0-0rc1/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_3_0-0rc1/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_0-0rc1/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_3_0-0rc1/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_1-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_3_1-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_1-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_3_1-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_1-1/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_3_1-1/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_1-1/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_3_1-1/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_1-2/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_3_1-2/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_1-2/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_3_1-2/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_2-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_3_2-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_2-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_3_2-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_2-1/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_3_2-1/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_2-1/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_3_2-1/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_3-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_3_3-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_3-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_3_3-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_3-1/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_3_3-1/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_3-1/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_3_3-1/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_3-2/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_3_3-2/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_3-2/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_3_3-2/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_3-3/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_3_3-3/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_3-3/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_3_3-3/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_4-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_3_4-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_4-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_3_4-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_5-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_3_5-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_5-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_3_5-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_6-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_3_6-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_6-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_3_6-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_7-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_3_7-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_7-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_3_7-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_8-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_3_8-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_3_8-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_3_8-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_0-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_4_0-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_0-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_4_0-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_1-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_4_1-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_1-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_4_1-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_2-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_4_2-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_2-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_4_2-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_3-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_4_3-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_3-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_4_3-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_3rc1/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_4_3rc1/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_3rc1/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_4_3rc1/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_4-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_4_4-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_4-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_4_4-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_4-1/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_4_4-1/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_4-1/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_4_4-1/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_5-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_4_5-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_5-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_4_5-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_6-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_4_6-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_6-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_4_6-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_7-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_4_7-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_7-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_4_7-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_7-1/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_4_7-1/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_7-1/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_4_7-1/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_8-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_4_8-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_8-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_4_8-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_8-1/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_4_8-1/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_8-1/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_4_8-1/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_8-2/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_4_8-2/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_8-2/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_4_8-2/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_8-3/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_4_8-3/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_8-3/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_4_8-3/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_8-4/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_4_8-4/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_8-4/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_4_8-4/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_8-5/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/2_4_8-5/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/2_4_8-5/alpine/apache/php5/docker-compose.yml
+++ b/versions/2_4_8-5/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0_0-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/3_0_0-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0_0-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/3_0_0-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0_0-0/alpine/apache/php7/Dockerfile
+++ b/versions/3_0_0-0/alpine/apache/php7/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.13.6
 
 LABEL maintainer="Public Knowledge Project <marc.bria@gmail.com>"
 WORKDIR /var/www/html

--- a/versions/3_0_0-0/alpine/apache/php7/docker-compose-local.yml
+++ b/versions/3_0_0-0/alpine/apache/php7/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0_0-0/alpine/apache/php7/docker-compose.yml
+++ b/versions/3_0_0-0/alpine/apache/php7/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0_1-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/3_0_1-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0_1-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/3_0_1-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0_1-0/alpine/apache/php7/Dockerfile
+++ b/versions/3_0_1-0/alpine/apache/php7/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.13.6
 
 LABEL maintainer="Public Knowledge Project <marc.bria@gmail.com>"
 WORKDIR /var/www/html

--- a/versions/3_0_1-0/alpine/apache/php7/docker-compose-local.yml
+++ b/versions/3_0_1-0/alpine/apache/php7/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0_1-0/alpine/apache/php7/docker-compose.yml
+++ b/versions/3_0_1-0/alpine/apache/php7/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0_2-0/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/3_0_2-0/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0_2-0/alpine/apache/php5/docker-compose.yml
+++ b/versions/3_0_2-0/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0_2-0/alpine/apache/php7/Dockerfile
+++ b/versions/3_0_2-0/alpine/apache/php7/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.13.6
 
 LABEL maintainer="Public Knowledge Project <marc.bria@gmail.com>"
 WORKDIR /var/www/html

--- a/versions/3_0_2-0/alpine/apache/php7/docker-compose-local.yml
+++ b/versions/3_0_2-0/alpine/apache/php7/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0_2-0/alpine/apache/php7/docker-compose.yml
+++ b/versions/3_0_2-0/alpine/apache/php7/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0a1/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/3_0a1/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0a1/alpine/apache/php5/docker-compose.yml
+++ b/versions/3_0a1/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0a1/alpine/apache/php7/Dockerfile
+++ b/versions/3_0a1/alpine/apache/php7/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.13.6
 
 LABEL maintainer="Public Knowledge Project <marc.bria@gmail.com>"
 WORKDIR /var/www/html

--- a/versions/3_0a1/alpine/apache/php7/docker-compose-local.yml
+++ b/versions/3_0a1/alpine/apache/php7/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0a1/alpine/apache/php7/docker-compose.yml
+++ b/versions/3_0a1/alpine/apache/php7/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0b1/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/3_0b1/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0b1/alpine/apache/php5/docker-compose.yml
+++ b/versions/3_0b1/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0b1/alpine/apache/php7/Dockerfile
+++ b/versions/3_0b1/alpine/apache/php7/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.13.6
 
 LABEL maintainer="Public Knowledge Project <marc.bria@gmail.com>"
 WORKDIR /var/www/html

--- a/versions/3_0b1/alpine/apache/php7/docker-compose-local.yml
+++ b/versions/3_0b1/alpine/apache/php7/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_0b1/alpine/apache/php7/docker-compose.yml
+++ b/versions/3_0b1/alpine/apache/php7/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_0-0/alpine/apache/php7/Dockerfile
+++ b/versions/3_1_0-0/alpine/apache/php7/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.13.6
 
 LABEL maintainer="Public Knowledge Project <marc.bria@gmail.com>"
 WORKDIR /var/www/html

--- a/versions/3_1_0-0/alpine/apache/php7/docker-compose-local.yml
+++ b/versions/3_1_0-0/alpine/apache/php7/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_0-0/alpine/apache/php7/docker-compose.yml
+++ b/versions/3_1_0-0/alpine/apache/php7/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_0-1/alpine/apache/php7/Dockerfile
+++ b/versions/3_1_0-1/alpine/apache/php7/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.13.6
 
 LABEL maintainer="Public Knowledge Project <marc.bria@gmail.com>"
 WORKDIR /var/www/html

--- a/versions/3_1_0-1/alpine/apache/php7/docker-compose-local.yml
+++ b/versions/3_1_0-1/alpine/apache/php7/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_0-1/alpine/apache/php7/docker-compose.yml
+++ b/versions/3_1_0-1/alpine/apache/php7/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_1-0/alpine/apache/php7/Dockerfile
+++ b/versions/3_1_1-0/alpine/apache/php7/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.13.6
 
 LABEL maintainer="Public Knowledge Project <marc.bria@gmail.com>"
 WORKDIR /var/www/html

--- a/versions/3_1_1-0/alpine/apache/php7/docker-compose-local.yml
+++ b/versions/3_1_1-0/alpine/apache/php7/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_1-0/alpine/apache/php7/docker-compose.yml
+++ b/versions/3_1_1-0/alpine/apache/php7/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_1-1/alpine/apache/php7/Dockerfile
+++ b/versions/3_1_1-1/alpine/apache/php7/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.13.6
 
 LABEL maintainer="Public Knowledge Project <marc.bria@gmail.com>"
 WORKDIR /var/www/html

--- a/versions/3_1_1-1/alpine/apache/php7/docker-compose-local.yml
+++ b/versions/3_1_1-1/alpine/apache/php7/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_1-1/alpine/apache/php7/docker-compose.yml
+++ b/versions/3_1_1-1/alpine/apache/php7/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_1-2/alpine/apache/php7/Dockerfile
+++ b/versions/3_1_1-2/alpine/apache/php7/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.13.6
 
 LABEL maintainer="Public Knowledge Project <marc.bria@gmail.com>"
 WORKDIR /var/www/html

--- a/versions/3_1_1-2/alpine/apache/php7/docker-compose-local.yml
+++ b/versions/3_1_1-2/alpine/apache/php7/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_1-2/alpine/apache/php7/docker-compose.yml
+++ b/versions/3_1_1-2/alpine/apache/php7/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_1-4/alpine/apache/php7/Dockerfile
+++ b/versions/3_1_1-4/alpine/apache/php7/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.13.6
 
 LABEL maintainer="Public Knowledge Project <marc.bria@gmail.com>"
 WORKDIR /var/www/html

--- a/versions/3_1_1-4/alpine/apache/php7/docker-compose-local.yml
+++ b/versions/3_1_1-4/alpine/apache/php7/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_1-4/alpine/apache/php7/docker-compose.yml
+++ b/versions/3_1_1-4/alpine/apache/php7/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_2-0/alpine/apache/php7/Dockerfile
+++ b/versions/3_1_2-0/alpine/apache/php7/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.13.6
 
 LABEL maintainer="Public Knowledge Project <marc.bria@gmail.com>"
 WORKDIR /var/www/html

--- a/versions/3_1_2-0/alpine/apache/php7/docker-compose-local.yml
+++ b/versions/3_1_2-0/alpine/apache/php7/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_2-0/alpine/apache/php7/docker-compose.yml
+++ b/versions/3_1_2-0/alpine/apache/php7/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_2-1/alpine/apache/php7/Dockerfile
+++ b/versions/3_1_2-1/alpine/apache/php7/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.13.6
 
 LABEL maintainer="Public Knowledge Project <marc.bria@gmail.com>"
 WORKDIR /var/www/html

--- a/versions/3_1_2-1/alpine/apache/php7/docker-compose-local.yml
+++ b/versions/3_1_2-1/alpine/apache/php7/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_2-1/alpine/apache/php7/docker-compose.yml
+++ b/versions/3_1_2-1/alpine/apache/php7/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_2-2/alpine/apache/php7/Dockerfile
+++ b/versions/3_1_2-2/alpine/apache/php7/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.13.6
 
 LABEL maintainer="Public Knowledge Project <marc.bria@gmail.com>"
 WORKDIR /var/www/html

--- a/versions/3_1_2-2/alpine/apache/php7/docker-compose-local.yml
+++ b/versions/3_1_2-2/alpine/apache/php7/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_2-2/alpine/apache/php7/docker-compose.yml
+++ b/versions/3_1_2-2/alpine/apache/php7/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_2-3/alpine/apache/php7/Dockerfile
+++ b/versions/3_1_2-3/alpine/apache/php7/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.13.6
 
 LABEL maintainer="Public Knowledge Project <marc.bria@gmail.com>"
 WORKDIR /var/www/html

--- a/versions/3_1_2-3/alpine/apache/php7/docker-compose-local.yml
+++ b/versions/3_1_2-3/alpine/apache/php7/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_2-3/alpine/apache/php7/docker-compose.yml
+++ b/versions/3_1_2-3/alpine/apache/php7/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_2-4/alpine/apache/php7/Dockerfile
+++ b/versions/3_1_2-4/alpine/apache/php7/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.13.6
 
 LABEL maintainer="Public Knowledge Project <marc.bria@gmail.com>"
 WORKDIR /var/www/html

--- a/versions/3_1_2-4/alpine/apache/php7/docker-compose-local.yml
+++ b/versions/3_1_2-4/alpine/apache/php7/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_2-4/alpine/apache/php7/docker-compose.yml
+++ b/versions/3_1_2-4/alpine/apache/php7/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_2-4/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_1_2-4/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_1_2-4/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_1_2-4/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_2_0-0/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_2_0-0/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_2_0-0/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_2_0-0/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_2_0-1/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_2_0-1/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_2_0-1/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_2_0-1/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_2_0-2/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_2_0-2/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_2_0-2/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_2_0-2/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_2_0-3/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_2_0-3/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_2_0-3/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_2_0-3/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_2_1-0/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_2_1-0/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_2_1-0/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_2_1-0/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_2_1-1/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_2_1-1/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_2_1-1/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_2_1-1/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_2_1-2/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_2_1-2/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_2_1-2/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_2_1-2/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_2_1-3/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_2_1-3/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_2_1-3/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_2_1-3/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_2_1-4/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_2_1-4/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_2_1-4/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_2_1-4/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_3_0-0/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_3_0-0/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_3_0-0/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_3_0-0/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_3_0-1/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_3_0-1/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_3_0-1/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_3_0-1/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_3_0-2/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_3_0-2/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_3_0-2/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_3_0-2/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_3_0-3/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_3_0-3/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_3_0-3/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_3_0-3/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_3_0-4/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_3_0-4/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_3_0-4/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_3_0-4/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_3_0-5/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_3_0-5/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_3_0-5/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_3_0-5/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_3_0-6/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_3_0-6/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_3_0-6/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_3_0-6/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_3_0-7/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_3_0-7/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_3_0-7/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_3_0-7/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_3_0-8/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/3_3_0-8/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/3_3_0-8/alpine/apache/php73/docker-compose.yml
+++ b/versions/3_3_0-8/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/latest/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/latest/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/latest/alpine/apache/php73/docker-compose.yml
+++ b/versions/latest/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/main/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/main/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/main/alpine/apache/php73/docker-compose.yml
+++ b/versions/main/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/stable-2_4_8/alpine/apache/php5/docker-compose-local.yml
+++ b/versions/stable-2_4_8/alpine/apache/php5/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/stable-2_4_8/alpine/apache/php5/docker-compose.yml
+++ b/versions/stable-2_4_8/alpine/apache/php5/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/stable-3_2_1/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/stable-3_2_1/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/stable-3_2_1/alpine/apache/php73/docker-compose.yml
+++ b/versions/stable-3_2_1/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/stable-3_3_1/alpine/apache/php73/docker-compose-local.yml
+++ b/versions/stable-3_3_1/alpine/apache/php73/docker-compose-local.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"

--- a/versions/stable-3_3_1/alpine/apache/php73/docker-compose.yml
+++ b/versions/stable-3_3_1/alpine/apache/php73/docker-compose.yml
@@ -36,7 +36,6 @@ services:
 #      - .env
     container_name: "ojs_app_${COMPOSE_PROJECT_NAME:-demo}"
     hostname: "${COMPOSE_PROJECT_NAME:-demo}"
-    restart: always
     ports:
       - "${HTTP_PORT:-8081}:80"
       - "${HTTPS_PORT:-443}:443"


### PR DESCRIPTION
In the `ojs` service part in `docker-compose.yml` and `docker-compose-local.yml`, `restart: always` is duplicated, which will raise warning in vscode linter.